### PR TITLE
fix(command-palette): smaller glyph card in preview pane

### DIFF
--- a/src/cmdpalette.c
+++ b/src/cmdpalette.c
@@ -281,9 +281,9 @@ static void update_preview(GtkListBoxRow *row, PaletteCtx *ctx)
         gtk_label_set_text(ctx->preview_glyph, shortcut);
         /* Large style for Unicode glyphs, smaller for keyboard shortcuts */
         if (cat == CAT_LATEX)
-            gtk_widget_add_css_class(GTK_WIDGET(ctx->preview_glyph), "title-1");
+            gtk_widget_add_css_class(GTK_WIDGET(ctx->preview_glyph), "title-2");
         else
-            gtk_widget_remove_css_class(GTK_WIDGET(ctx->preview_glyph), "title-1");
+            gtk_widget_remove_css_class(GTK_WIDGET(ctx->preview_glyph), "title-2");
     }
 
     /* Title */


### PR DESCRIPTION
## Summary

- Use `title-2` instead of `title-1` for LaTeX glyph preview — smaller size fits the pane better
- Rebase on master to pick up the HiDPI blurry-preview fix that landed in #30

## Test plan
- [ ] Open command palette, search a LaTeX symbol — glyph in preview pane should be smaller than before
- [ ] Blurry preview fix still intact (HiDPI display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)